### PR TITLE
fix: Dtk module file configurability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ include(GNUInstallDirs)
 message(${PROJECT_VERSION})
 set(LINUXNAME "debian")
 option(LINUXNAME "linuxname" "debian")
+set (MKSPECS_INSTALL_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/qt5/mkspecs" CACHE STRING "INSTALL DIR FOR qt pri files")
+
 set(SPECPATH "qt5/mkspecs/")
 
 if (${LINUXNAME} STREQUAL "archlinux")
@@ -28,8 +30,8 @@ set(MODULE_INCLUDES ${CMAKE_INSTALL_FULL_INCLUDEDIR}/libdtk-${PROJECT_VERSION})
 set(MODULE_TOOLS ${CMAKE_INSTALL_FULL_LIBDIR}/libdtk-${PROJECT_VERSION})
 configure_file(misc/qt_lib_dtkcommon.pri.in qt_lib_dtkcommon.pri @ONLY)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/qt_lib_dtkcommon.pri DESTINATION "${CMAKE_INSTALL_LIBDIR}/${SPECPATH}/modules")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/qt_lib_dtkcommon.pri DESTINATION "${MKSPECS_INSTALL_DIR}/modules")
 install(FILES schemas/com.deepin.dtk.gschema.xml DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/glib-2.0/schemas")
-install(DIRECTORY features DESTINATION "${CMAKE_INSTALL_LIBDIR}/${SPECPATH}" FILES_MATCHING PATTERN "*" )
+install(DIRECTORY features DESTINATION "${MKSPECS_INSTALL_DIR}" FILES_MATCHING PATTERN "*" )
 install(DIRECTORY cmake DESTINATION "${CMAKE_INSTALL_LIBDIR}" FILES_MATCHING  PATTERN "*" )
 


### PR DESCRIPTION
Through a Unified Variable ` MKSPECS_ INSTALL_ DIR `, which controls the installation path of Dtk configuration files and module files.

Log:
Change-Id: Ife0dc7b7d81050b537326d0defbc47bb8c3f0c36