### PR TITLE
chore: can't find DtkBuildHelper in Dtk6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,3 +33,4 @@ configure_file(
   @ONLY
 )
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Dtk6Config.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Dtk6")
+install(FILES "${CMAKE_SOURCE_DIR}/cmake/DtkBuildHelper.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Dtk6")


### PR DESCRIPTION
install DtkBuildHelper in Dtk6