### PR TITLE
fix: update default logging rules in dtk preference

### DIFF
--- a/configs/org.deepin.dtk.preference.json
+++ b/configs/org.deepin.dtk.preference.json
@@ -64,7 +64,7 @@
             "visibility": "public"
         },
         "rules": {
-            "value": "",
+            "value": "*.debug=false",
             "serial": 0,
             "flags": [],
             "name": "The logging rules of dtk applications",


### PR DESCRIPTION
Changed the default logging rules value from empty string to
"*.debug=false" in org.deepin.dtk.preference.json
This modification ensures debug logs are disabled by default for DTK
applications
The change helps reduce unnecessary debug output in production
environments while maintaining the ability to enable debug logging when
needed

fix: 更新 dtk 首选项中的默认日志规则

将 org.deepin.dtk.preference.json 中的默认日志规则值从空字符串改为
"*.debug=false"
此修改确保 DTK 应用程序默认禁用调试日志
该更改有助于减少生产环境中不必要的调试输出，同时保留需要时启用调试日志的
能力
