### PR TITLE
fix: make version optional in release workflow and update RPM spec

### DIFF
--- a/.github/workflows/call-auto-release.yml
+++ b/.github/workflows/call-auto-release.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: 'Release version (e.g., 1.0.0)'
         type: string
-        required: true
+        required: false
       name:
         description: 'The name of the person to release the version'
         type: string

--- a/rpm/dtkcommon.spec
+++ b/rpm/dtkcommon.spec
@@ -1,11 +1,14 @@
-Name:    dtkcommon
-Version: 5.7.17
-Release: 1
-Summary: dtk common files
-Source0: %{name}-%{version}.orig.tar.xz
-
-License: GPLv3
-
+Name:           dtkcommon
+Version:        5.7.17
+Release:        1%{?dist}
+Summary:        dtk common files
+License:        LGPLv3+
+URL:            https://github.com/linuxdeepin/dtkcommon
+%if 0%{?fedora}
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+%else
+Source0:        %{name}-%{version}.orig.tar.xz
+%endif
 BuildRequires:  qt5-qtbase-devel
 
 Obsoletes:      dtkcore <= 5.4.10


### PR DESCRIPTION
1. Changed version parameter to optional in GitHub workflow to allow
more flexible releases
2. Updated RPM spec file with:
   - Added conditional source URL handling for Fedora
   - Improved formatting and metadata (License, URL)
   - Added %{?dist} macro to Release field
3. These changes improve package maintainability and support different
build environments

fix: 使发布工作流中的版本可选并更新 RPM 规范

1. 将 GitHub 工作流中的版本参数改为可选，以实现更灵活的发布
2. 更新 RPM 规范文件：
   - 为 Fedora 添加了条件式源 URL 处理
   - 改进了格式和元数据（许可证、URL）
   - 在 Release 字段中添加了 %{?dist} 宏
3. 这些更改提高了软件包的可维护性并支持不同的构建环境
