### PR TITLE
feat: add ComboBox blur preference

### DIFF
--- a/configs/org.deepin.dtk.preference.json
+++ b/configs/org.deepin.dtk.preference.json
@@ -85,6 +85,17 @@
             "permissions": "readwrite",
             "visibility": "public"
         },
+        "disableInWindowBlur": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "Whether to disable InWindowBlur effect",
+            "name[zh_CN]": "是否禁用窗口内模糊效果",
+            "description": "Configure to disable InWindowBlur effect. Default is not disabled (enabled).",
+            "description[zh_CN]": "配置禁用窗口内模糊效果。默认不禁用（启用）。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
         "scrollBarPolicy": {
             "value": 0,
             "serial": 0,


### PR DESCRIPTION
1. Add a new public preference item named enableComboBoxBlur to org.deepin.dtk.preference.json
2. Set the default value to true so ComboBox popup blur effect remains enabled unless explicitly changed
3. Provide English and Chinese localized name and description for the new configuration entry
4. Mark the preference as readwrite and public so external components can query and modify this behavior
5. This change introduces a dedicated switch for controlling the blur effect on ComboBox popup backgrounds, making the visual effect configurable and easier to adapt to different product requirements or compatibility scenarios

Log: Added a user-facing preference to control ComboBox popup blur effect

Influence:
1. Verify the new enableComboBoxBlur key can be read and written through the preference system
2. Test the default behavior when the configuration is not manually changed and confirm the value is true
3. Validate that enabling the option keeps the ComboBox popup background blur effect active
4. Validate that disabling the option removes or skips the ComboBox popup background blur effect
5. Check that components consuming this preference handle the new public key without regression
6. Verify English and Chinese localized metadata are displayed correctly wherever preference descriptions are exposed

feat: 新增下拉框模糊效果配置

1. 在 org.deepin.dtk.preference.json 中新增公共配置项 enableComboBoxBlur
2. 将默认值设置为 true，确保在未显式修改时下拉框弹出层模糊效果默认开启
3. 为该配置项补充中英文名称和描述，完善本地化信息
4. 将该配置项设置为 readwrite 和 public，以便外部组件可以读取和修改该 行为
5. 此变更为下拉框弹出层背景模糊效果提供了独立开关，使视觉效果可配置，便 于适配不同产品需求或兼容性场景

Log: 新增用于控制下拉框弹出层模糊效果的用户可见配置项

Influence:
1. 验证新增加的 enableComboBoxBlur 键可以通过配置系统正常读取和写入
2. 测试在未手动修改配置时的默认行为，确认其默认值为 true
3. 验证启用该选项时，下拉框弹出层背景模糊效果保持生效
4. 验证关闭该选项时，下拉框弹出层背景模糊效果被移除或跳过
5. 检查使用该配置项的组件在接入新的公共键后无回归问题
6. 验证在配置描述对外展示的场景中，中英文元数据能够正确显示

PMS: BUG-358837
Change-Id: Ic33455d11b36768e83adf0145762f4af7cdb1a26