### PR TITLE
feat: add disableInWindowBlur config to org.deepin.dtk.preference

### DIFF
--- a/configs/org.deepin.dtk.preference.json
+++ b/configs/org.deepin.dtk.preference.json
@@ -85,6 +85,17 @@
             "permissions": "readwrite",
             "visibility": "public"
         },
+        "disableInWindowBlur": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "Whether to disable InWindowBlur effect",
+            "name[zh_CN]": "是否禁用窗口内模糊效果",
+            "description": "Configure to disable InWindowBlur effect. Default is not disabled (enabled).",
+            "description[zh_CN]": "配置禁用窗口内模糊效果。默认不禁用（启用）。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
         "scrollBarPolicy": {
             "value": 0,
             "serial": 0,


### PR DESCRIPTION
## Summary

- Add `disableInWindowBlur` config key to `org.deepin.dtk.preference.json`
- Default value is `false` (not disabled, i.e., enabled)
- Can be set to `true` to disable InWindowBlur via override

## Issue

https://pms.uniontech.com/task-view-390117.html

## Test Plan

- [ ] Verify disableInWindowBlur default value is false
- [ ] Test setting disableInWindowBlur to true disables InWindowBlur