### PR TITLE
chore: update changelog to 6.7.43

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dtkcommon (6.7.43) unstable; urgency=medium
+
+  * feat: add disableInWindowBlur config to org.deepin.dtk.preference
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Jun 2026 19:33:09 +0800
+
 dtkcommon (6.7.42) unstable; urgency=medium
 
   * Release 6.7.42


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.7.43

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.7.43
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh debian/changelog entries to document version 6.7.43.