### PR TITLE
chore: adjust default logging level to disable info output

### DIFF
--- a/configs/org.deepin.dtk.preference.json
+++ b/configs/org.deepin.dtk.preference.json
@@ -64,8 +64,8 @@
             "visibility": "public"
         },
         "rules": {
-            "value": "*.debug=false",
-            "serial": 1,
+            "value": "*.debug=false,*.info=false",
+            "serial": 2,
             "flags": ["global"],
             "name": "The logging rules of dtk applications",
             "name[zh_CN]": "日志输出的规则配置",


### PR DESCRIPTION
1. Change the default logging rules from suppressing only debug messages
to suppressing both debug and info messages
2. The update adds `*.info=false` to the existing `*.debug=false` rule
3. This change reduces log verbosity by removing info-level logging
output by default

Log: Adjusted default logging level to exclude info-level messages

Influence:
1. Verify that debug and info level logs are no longer displayed by
default
2. Confirm that warning and error level logs remain visible
3. Test custom logging configuration to ensure it can override the
default rules

chore: 调整日志默认输出等级，取消info级别输出

1. 将默认日志规则从仅禁止debug消息调整为同时禁止debug和info消息
2. 该更新在现有`*.debug=false`规则基础上添加了`*.info=false`
3. 此变更通过默认移除info级别日志输出来降低日志冗长度

Log: 调整默认日志级别，屏蔽info级别信息

Influence:
1. 验证debug和info级别日志默认不再显示
2. 确认warning和error级别日志仍然可见
3. 测试自定义日志配置能否覆盖默认规则

PMS: BUG-366227

## Summary by Sourcery

Enhancements:
- Update global logging rules to disable info-level output in addition to existing debug suppression, reducing default log verbosity.