### PR TITLE
fix: correct log rules separator in dtk preference config

### DIFF
--- a/configs/org.deepin.dtk.preference.json
+++ b/configs/org.deepin.dtk.preference.json
@@ -64,7 +64,7 @@
             "visibility": "public"
         },
         "rules": {
-            "value": "*.debug=false,*.info=false",
+            "value": "*.debug=false;*.info=false",
             "serial": 2,
             "flags": ["global"],
             "name": "The logging rules of dtk applications",


### PR DESCRIPTION
1. Change the separator in logging rules from comma to semicolon
2. Update the serial number to reflect the configuration change

Log: Fixed logging rules separator from comma to semicolon in dtk
configuration

Influence:
1. Verify that logging rules are correctly parsed with semicolon
separator
2. Test logging behavior to ensure proper filtering with updated rules
3. Confirm configuration serial number is incremented correctly

fix: 修正 dtk 配置中日志规则的分隔符

1. 将日志规则中的分隔符从逗号改为分号
2. 更新序列号以反映配置变更

Log: 修复 dtk 配置中日志规则分隔符从逗号改为分号

Influence:
1. 验证分号分隔的日志规则能被正确解析
2. 测试日志过滤功能是否按更新后的规则正常工作
3. 确认配置序列号正确递增

## Summary by Sourcery

Bug Fixes:
- Correct logging rules separator in DTK preference configuration so rules are parsed correctly.